### PR TITLE
Update vegaproject-edit.yaml

### DIFF
--- a/base/rbac.authorization.k8s.io/clusterroles/vegaproject-edit.yaml
+++ b/base/rbac.authorization.k8s.io/clusterroles/vegaproject-edit.yaml
@@ -13,8 +13,4 @@ rules:
   - calculationbulkfactories
   - workerpools
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - delete
+  - "*"


### PR DESCRIPTION
Original cluster role gave these permissions:
  - get
  - list
  - watch
  - create
  - delete 
 This misses out the update and patch verbs